### PR TITLE
Enable compression for faster download of history

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/owntracks/frontend)](https://hub.docker.com/r/owntracks/frontend)
 
-![OwnTracks UI](docs/images/owntracks-ui.png)
+<p style="text-align: center;">
+  <img src="docs/images/owntracks-ui.png" alt="OwnTracks UI">
+</p>
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 > A modern web interface for OwnTracks made with Vue.js
 
-![Docker Pulls](https://img.shields.io/docker/pulls/owntracks/frontend)
+[![Docker Pulls](https://img.shields.io/docker/pulls/owntracks/frontend)](https://hub.docker.com/r/owntracks/frontend)
 
-<p style="text-align: center;">
-  <img src="docs/images/owntracks-ui.png" alt="OwnTracks UI">
-</p>
+![OwnTracks UI](docs/images/owntracks-ui.png)
 
 ## Introduction
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -22,6 +22,14 @@ http {
             include /etc/nginx/mime.types;
             try_files $uri $uri/index.html;
         }
+        
+        gzip on;
+        gzip_vary on;
+        gzip_proxied any;
+        gzip_comp_level 6;
+        gzip_buffers 16 8k;
+        gzip_http_version 1.1;
+        gzip_types text/plain text/css application/json application/javascript text/javascript;
     }
 }
 


### PR DESCRIPTION
This PR enables compression on nginx, mostly for the big json files containing the history of tracks. On my machine, the history for one month is 5 Mo and as my server's upload speed is pretty slow, it was taking a very long time to load. This doesn't make it perfect but it still is way faster.