### PR TITLE
Replace Travis CI with GitHub Actions build/lint/test workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: install
+      - name: Run production build
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: 'Build Docker images for multiple architectures'
+name: Build Docker images
 
 on:
   schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint code
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: install
+      - name: Lint JavaScript/Vue files
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: lint:js
+      - name: Lint Markdown files
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: lint:md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: install
+      - name: Run unit tests
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - 10
-cache: yarn
-script:
-  - yarn lint:js
-  - yarn lint:md
-  - yarn test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Version](https://img.shields.io/github/package-json/v/owntracks/frontend)
 [![Docker Pulls](https://img.shields.io/docker/pulls/owntracks/frontend)](https://hub.docker.com/r/owntracks/frontend)
-[![Build Status](https://travis-ci.org/owntracks/frontend.svg?branch=master)](https://travis-ci.org/owntracks/frontend)
+[![Build](https://github.com/owntracks/frontend/workflows/Build/badge.svg)](https://github.com/owntracks/frontend/actions)
 [![License](https://img.shields.io/github/license/owntracks/frontend?color=d63e97)](https://github.com/owntracks/frontend/blob/master/LICENSE)
 
 ![OwnTracks UI](https://raw.githubusercontent.com/owntracks/frontend/master/docs/images/owntracks-ui.png)


### PR DESCRIPTION
Would be neat to have it all in one place, also GitHub Actions integration in GitHub is obviously better than Travis.