### PR TITLE
Fix Slice in API URL Processing

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -12,7 +12,7 @@ import { DATE_TIME_FORMAT, EARTH_RADIUS_IN_KM } from "@/constants";
  */
 export const getApiUrl = (path) => {
   const normalizedBaseUrl = config.api.baseUrl.endsWith("/")
-    ? config.api.baseUrl.slice(1)
+    ? config.api.baseUrl.slice(0,-1)
     : config.api.baseUrl;
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return new URL(`${normalizedBaseUrl}${normalizedPath}`);


### PR DESCRIPTION
For some reason when I was debugging why my custom config.js wasn't working, I realized it was sending requests to ttps://url/ instead of https://url (no slash at end), which I traced back to this.
```
window.owntracks.config = {
api: {
baseURL: "https://something/"
},
};
```
I haven't set up a build environment or tested this since it was such a minor change. Hopefully, this fixes the issue.