### PR TITLE
NGINX should listen on IPv6 as well

### DIFF
--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -8,6 +8,7 @@ http {
     }
     server {
         listen ${LISTEN_PORT};
+        listen [::]:${LISTEN_PORT};        
         root /usr/share/nginx/html;
         location /api {
             proxy_pass http://otrecorder/api/;


### PR DESCRIPTION
I've got an ipv6 k8s cluster, and need the pod to listen to [::] so that an ipv6 k8s service can connect through to it.