### PR TITLE
Configure Vue to not assume it's on the web root

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -6,6 +6,7 @@ const packageJson = fs.readFileSync("./package.json");
 const version = JSON.parse(packageJson).version;
 
 module.exports = {
+  publicPath: "",
   configureWebpack: {
     plugins: [
       new webpack.DefinePlugin({


### PR DESCRIPTION
Not sure if this will have much knock-on effects, but when trying to run the frontend on a non-root path, I noticed that the generated output assumes that `config` etc are all available on `/`, which isn't necessarily the case.

Setting `publicPath` to be `""` seems to make it try and resolve dependencies relative to `index.html`, which feels like the right thing to do.