### PR TITLE
Add trailing slashes to location blocks

### DIFF
--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -10,10 +10,10 @@ http {
         listen ${LISTEN_PORT};
         listen [::]:${LISTEN_PORT};        
         root /usr/share/nginx/html;
-        location /api {
+        location /api/ {
             proxy_pass http://otrecorder/api/;
         }
-        location /ws {
+        location /ws/ {
             proxy_pass http://otrecorder/ws/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
On my configuration, having a trailing slash on `proxy_pass` but not on the location block causes the sub-path after the `location` to be appended to the `proxy_pass` url, causing a double-forward-slash. E.g. going to `/api/0/list` actually ends up making a call to the proxy of `http://otrecorder/api//0/list`, which fails for me.

Should the location block spec match the `proxy_pass` in terms of trailing slashes?