### PR TITLE
Display address in device location popup

### DIFF
--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -53,6 +53,7 @@
           :regions="l.inregions"
           :wifi="{ ssid: l.SSID, bssid: l.BSSID }"
           :options="{ className: 'leaflet-popup--for-pin' }"
+          :address="l.addr"
         />
       </LMarker>
     </template>
@@ -92,6 +93,7 @@
               :speed="l.vel"
               :regions="l.inregions"
               :wifi="{ ssid: l.SSID, bssid: l.BSSID }"
+              :address="l.addr"
             ></LDeviceLocationPopup>
           </LCircleMarker>
         </template>


### PR DESCRIPTION
`addr` is part of the response for reverse geolocation lookups. `address` is already used in `LDeviceLocationPopup` and `addr` needs to be passed in from the map.

![image](https://user-images.githubusercontent.com/663578/158265707-e3e7373b-48a1-4f6b-b4c7-32d7e72495f9.png)

Closes #31