### PR TITLE
Add zoomOffset and tileSize options

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -408,6 +408,14 @@ and [this Wikipedia article](https://en.wikipedia.org/wiki/Tiled_web_map).
   };
   ```
 
+### `map.zoomOffset`
+
+Offset the zoom level to account for different tile sizes. For example tiles with a 
+size of 512x512 need an offset of -1 and for 1024x1024 an offset of -2.
+
+- Type: [`Number`]
+- Default: `0`
+
 ### `onLocationChange.fitView`
 
 Whether to re-fit the map's content into view or not when a location update is received.

--- a/docs/config.md
+++ b/docs/config.md
@@ -391,6 +391,14 @@ for all possible values.
   }
   ```
 
+### `map.tileSize`
+
+Size of the tiles in pixels returned by the tile server. Can be used together with
+[`map.zoomOffset`](#map.zoomOffset) to configure bigger tile sizes.
+
+- Type: [`Number`]
+- Default: `256`
+
 ### `map.url`
 
 Tile server URL. For more information see [Leaflet tile layer documentation](https://leafletjs.com/reference-1.5.0.html#tilelayer-url-template)

--- a/src/config.js
+++ b/src/config.js
@@ -64,6 +64,7 @@ const DEFAULT_CONFIG = {
       color: null,
       fillColor: "transparent",
     },
+    tileSize: 256,
     url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
     zoomOffset: 0,
   },

--- a/src/config.js
+++ b/src/config.js
@@ -65,6 +65,7 @@ const DEFAULT_CONFIG = {
       fillColor: "transparent",
     },
     url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    zoomOffset: 0,
   },
   onLocationChange: {
     fitView: false,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,6 +56,7 @@ interface Config {
           fillColor: OptionalColor;
         };
         url: string;
+        zoomOffset: number;
     };
     onLocationChange: {
         fitView: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,6 +55,7 @@ interface Config {
           color: OptionalColor;
           fillColor: OptionalColor;
         };
+        tileSize: number;
         url: string;
         zoomOffset: number;
     };

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -21,7 +21,7 @@
     <LTileLayer
       :url="url"
       :attribution="attribution"
-      :options="{ maxNativeZoom, maxZoom }"
+      :options="{ maxNativeZoom, maxZoom, zoomOffset }"
     />
 
     <template v-if="map.layers.last">
@@ -156,6 +156,7 @@ export default {
       maxNativeZoom: this.$config.map.maxNativeZoom,
       url: this.$config.map.url,
       zoom: this.$store.state.map.zoom,
+      zoomOffset: this.$config.map.zoomOffset,
       circle: {
         ...this.$config.map.circle,
         color: this.$config.map.circle.color || this.$config.primaryColor,

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -21,6 +21,7 @@
     <LTileLayer
       :url="url"
       :attribution="attribution"
+      :tileSize="tileSize"
       :options="{ maxNativeZoom, maxZoom, zoomOffset }"
     />
 
@@ -154,6 +155,7 @@ export default {
       markerIcon: LCustomMarker,
       maxZoom: this.$config.map.maxZoom,
       maxNativeZoom: this.$config.map.maxNativeZoom,
+      tileSize: this.$config.map.tileSize,
       url: this.$config.map.url,
       zoom: this.$store.state.map.zoom,
       zoomOffset: this.$config.map.zoomOffset,


### PR DESCRIPTION
[LeafletJS offers an option for an offset which is applied to the zoom level][1] given in the URL. This is helpful when big tile sizes are used and the zoom level needs to be adjusted for the increased tile size. Bigger tile sizes can be beneficial to decrease the amount of requests to fetch all map tiles.

From the [Mapbox documentation][2] on 512px tiles:

> Note that 512×512 image tiles are offset by one zoom level compared to 256×256 tiles. For example, 512×512 tiles at zoom level 4 are equivalent to 256×256 tiles at zoom level 5.

When bigger tile sizes are used `LTileLayer` has to be configured as well using the [`tileSize` prop][3].

A setting of `tileSize=512` and `zoomOffset=-1` will result in an identical map image to using `tileSize=256` and `zoomOffset=0` but with a quarter of tile requests.

[1]: https://leafletjs.com/SlavaUkraini/reference.html#tilelayer-zoomoffset
[2]: https://docs.mapbox.com/api/maps/static-tiles
[3]: https://vue2-leaflet.netlify.app/components/LTileLayer.html#props