### PR TITLE
Define a face style

### DIFF
--- a/src/components/LDeviceLocationPopup.vue
+++ b/src/components/LDeviceLocationPopup.vue
@@ -7,6 +7,7 @@
         :src="faceImageDataURI"
         :alt="$t('Image of {deviceName}', { deviceName })"
         :title="$t('Image of {deviceName}', { deviceName })"
+        class="face"
       />
       <ul class="info-list">
         <li :title="$t('Timestamp')">

--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -15,6 +15,11 @@
 
       .leaflet-popup-content {
         margin: 30px;
+
+        .face {
+          width: 40px;
+          border-radius: 3px;
+        }
       }
     }
 


### PR DESCRIPTION
Hi and thanks for making this very cool addition to owntracks!

Currently, the size of a face image in a popup is determined by the size of the image uploaded by the user. This can make popups look wonky because their layout will change based on this arbitrary image size, and it can even break the layout completely with a sufficiently large face:
![Screenshot from 2022-04-18 02-39-35](https://user-images.githubusercontent.com/20535393/163740171-67001bfc-aad4-4438-9f4e-4dd05a82a04c.png)

This change fixes the images to a specific size, no matter their original resolution:
![Screenshot from 2022-04-18 03-16-18](https://user-images.githubusercontent.com/20535393/163740201-f9b3fd63-feb3-436d-8880-c99e78be630d.png)

While I was there, I also took the liberty of rounding the corners a bit. I think it looks much nicer that way :)

I am not sure which image sizes are officially allowed right now, but I have opened a discussion to allow images of any size over at owntracks/talk#138, and if that change is accepted, then this fix will be pretty important.
