### PR TITLE
Add action for uploading dist/ on release

### DIFF
--- a/.github/workflows/upload-dist.yml
+++ b/.github/workflows/upload-dist.yml
@@ -1,0 +1,20 @@
+name: Upload dist/
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  upload-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm run build
+      - run: zip -r $GITHUB_REF_NAME-dist.zip dist/
+      - run: gh release upload $GITHUB_REF_NAME $GITHUB_REF_NAME-dist.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes #90 by adding a GitHub Action which runs whenever a new release was created. It creates a build, zips it and adds the zip file to the previously created release.

Feedback is welcome.