### PR TITLE
nginx: increase read timeout

### DIFF
--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -31,6 +31,7 @@ http {
         gzip_buffers 16 8k;
         gzip_http_version 1.1;
         gzip_types text/plain text/css application/json application/javascript text/javascript;
+        proxy_read_timeout 600;
     }
 }
 


### PR DESCRIPTION
The default value is 60 seconds. I wanted to load a couple of years data, which on my setup takes recorder 3 minutes to respond, so nginx was aborting the request. Increasing it to 10 minutes, because it _ought to be enough for anybody_ :tm: :grin: (jokes aside, feel free to pick another constant you like more).

Unfortunately it doesn't help me actually see a map of my travels, as the web doesn't seem to handle that amount of data:

> RangeError: too many arguments provided for a function call
> ... (stack trace of minified javascript)

I don't know if this is a use-case you want to support (in which case we can continue investigating this separately), but I feel like increasing the timeout is useful in any case, especially for smaller & slower servers.