### PR TITLE
Better handling of trips which cross the antimeridian

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "vue-feather-icons": "^5.1.0",
         "vue-i18n": "^8.28.2",
         "vue-js-modal": "^2.0.1",
-        "vue-leaflet-antimeridian": "^1.0.0",
+        "vue-leaflet-antimeridian": "^1.0.1",
         "vue-mq": "^1.0.1",
         "vue-outside-events": "^1.1.3",
         "vue-router": "^3.6.5",
@@ -2720,11 +2720,6 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
-    "node_modules/Leaflet.Antimeridian": {
-      "name": "leaflet.antimeridian",
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/briannaAndCo/Leaflet.Antimeridian.git#7986dc5b68836630611c15dcbd8c8c48409d5798"
-    },
     "node_modules/leaflet.heat": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/leaflet.heat/-/leaflet.heat-0.2.0.tgz",
@@ -4551,11 +4546,10 @@
       }
     },
     "node_modules/vue-leaflet-antimeridian": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-leaflet-antimeridian/-/vue-leaflet-antimeridian-1.0.0.tgz",
-      "integrity": "sha512-lnvXzMPlFhZubT6cMwi4GEPBhGYtwQrbR3LP5bSyUI9hVBTN3vlJFTqhEPmyQSBpqAjI7W4zZt/aJpn+VzZuNQ==",
-      "dependencies": {
-        "Leaflet.Antimeridian": "github:briannaAndCo/Leaflet.Antimeridian",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vue-leaflet-antimeridian/-/vue-leaflet-antimeridian-1.0.1.tgz",
+      "integrity": "sha512-2mhyi0QMafDGynayfuK3miTZCHi0ENXKetYc/qcwFR6Ly9Ar+C0yMEZGU+tpsgyC+NjY9bU+F8XYoIULSa1KWg==",
+      "peerDependencies": {
         "vue2-leaflet": "^2.7.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "vue-feather-icons": "^5.1.0",
         "vue-i18n": "^8.28.2",
         "vue-js-modal": "^2.0.1",
+        "vue-leaflet-antimeridian": "^1.0.0",
         "vue-mq": "^1.0.1",
         "vue-outside-events": "^1.1.3",
         "vue-router": "^3.6.5",
@@ -2719,6 +2720,11 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
+    "node_modules/Leaflet.Antimeridian": {
+      "name": "leaflet.antimeridian",
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/briannaAndCo/Leaflet.Antimeridian.git#7986dc5b68836630611c15dcbd8c8c48409d5798"
+    },
     "node_modules/leaflet.heat": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/leaflet.heat/-/leaflet.heat-0.2.0.tgz",
@@ -4542,6 +4548,15 @@
       },
       "peerDependencies": {
         "vue": "^2.6.11"
+      }
+    },
+    "node_modules/vue-leaflet-antimeridian": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vue-leaflet-antimeridian/-/vue-leaflet-antimeridian-1.0.0.tgz",
+      "integrity": "sha512-lnvXzMPlFhZubT6cMwi4GEPBhGYtwQrbR3LP5bSyUI9hVBTN3vlJFTqhEPmyQSBpqAjI7W4zZt/aJpn+VzZuNQ==",
+      "dependencies": {
+        "Leaflet.Antimeridian": "github:briannaAndCo/Leaflet.Antimeridian",
+        "vue2-leaflet": "^2.7.1"
       }
     },
     "node_modules/vue-mq": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "vue-feather-icons": "^5.1.0",
     "vue-i18n": "^8.28.2",
     "vue-js-modal": "^2.0.1",
-    "vue-leaflet-antimeridian": "^1.0.0",
+    "vue-leaflet-antimeridian": "^1.0.1",
     "vue-mq": "^1.0.1",
     "vue-outside-events": "^1.1.3",
     "vue-router": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "vue-feather-icons": "^5.1.0",
     "vue-i18n": "^8.28.2",
     "vue-js-modal": "^2.0.1",
+    "vue-leaflet-antimeridian": "^1.0.0",
     "vue-mq": "^1.0.1",
     "vue-outside-events": "^1.1.3",
     "vue-router": "^3.6.5",

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -141,9 +141,9 @@ import {
   LMarker,
   LCircleMarker,
   LCircle,
-  LPolyline,
   LTooltip,
 } from "vue2-leaflet";
+import { LPolyline } from "vue-leaflet-antimeridian";
 import "leaflet/dist/leaflet.css";
 import * as types from "@/store/mutation-types";
 import LCustomMarker from "@/components/LCustomMarker";


### PR DESCRIPTION
## Problem this solves

When a line crosses the antimeridian (ie the 180th meridian), the default leaflet behaviour is to draw the line going the other way around the world.  For example, San Francisco to Tokyo is drawn like so:
<img width="1032" height="700" alt="image" src="https://github.com/user-attachments/assets/7c69dd56-fd4e-4ad9-b7e0-73f3ac3a5481" />

This change will now draw that same journey using the shorter route, across the Pacific Ocean:

<img width="1027" height="680" alt="image" src="https://github.com/user-attachments/assets/6c5d126d-41d7-456e-9866-b4a8679d7b72" />

Fixes #157 

## Implementation

* I found an existing library which already fixes this problem in leaflet: https://github.com/briannaAndCo/Leaflet.Antimeridian
* I wrote a new module which uses this library and makes it available as a vue component: https://github.com/lucas42/vue-leaflet-antimeridian
* This PR uses that new module's version of `LPolyline`, instead of the native leaflet one.

## Caveats

* [Leaflet.Antimeridian](https://github.com/briannaAndCo/Leaflet.Antimeridian) hasn't been update since 2017, so is unlikely to receive ongoing support.
* I've never written any vue or leaflet before attempting this.  If anyone wants to review [the module I wrote](https://github.com/lucas42/vue-leaflet-antimeridian), I'm happy to take feedback on that too.


## Reason for doing this
To be fully honest, I only did this because I recently completed a round-the-world trip and I wanted to make a nice map of my journey so I can brag on social media:
<img width="1027" height="564" alt="image" src="https://github.com/user-attachments/assets/fddfbb21-cdc0-47b1-aef1-46478dca9353" />
